### PR TITLE
feat: show available sizes on catalogue cards

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -69,6 +69,13 @@ def list_products(
         ).fetchone()
         p["image_url"] = img["image_url"] if img else None
 
+        # Attach in-stock sizes to each product card
+        sizes = conn.execute(
+            "SELECT size_label FROM product_sizes WHERE product_id = ? AND in_stock = 1 ORDER BY size_label",
+            (p["id"],),
+        ).fetchall()
+        p["sizes"] = [s["size_label"] for s in sizes]
+
     conn.close()
 
     if sort == "price_asc":

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -235,6 +235,35 @@ body {
     margin-bottom: 12px;
 }
 
+/* ===== Size Pills on Cards ===== */
+
+.card-sizes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 10px;
+}
+
+.size-pill {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    padding: 2px 7px;
+    border-radius: 4px;
+    font-size: 0.68rem;
+    font-family: var(--font-mono);
+    color: var(--text-secondary);
+    line-height: 1.4;
+}
+
+.size-pill-more {
+    background: var(--accent-glow);
+    border-color: var(--accent);
+    color: var(--accent);
+    font-weight: 600;
+}
+
+/* ===== Card Prices & Store ===== */
+
 .card-prices {
     display: flex;
     align-items: baseline;
@@ -565,5 +594,10 @@ body {
         flex-direction: column;
         gap: 4px;
         text-align: center;
+    }
+
+    .size-pill {
+        font-size: 0.6rem;
+        padding: 1px 5px;
     }
 }

--- a/frontend/js/catalog.js
+++ b/frontend/js/catalog.js
@@ -130,6 +130,15 @@ function renderCard(p) {
         ? `<img src="${p.image_url}" alt="${p.name}" loading="lazy">`
         : '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted)">No image</div>';
 
+    // Render size pills (show max 8, then "+N more")
+    let sizesHtml = '';
+    if (p.sizes && p.sizes.length) {
+        const maxShow = 8;
+        const visible = p.sizes.slice(0, maxShow);
+        const remaining = p.sizes.length - maxShow;
+        sizesHtml = `<div class="card-sizes">${visible.map(s => `<span class="size-pill">${esc(s)}</span>`).join('')}${remaining > 0 ? `<span class="size-pill size-pill-more">+${remaining}</span>` : ''}</div>`;
+    }
+
     return `
         <div class="product-card ${p.in_stock ? '' : 'sold-out'}" data-slug="${p.slug}">
             <div class="card-image-wrap">
@@ -140,6 +149,7 @@ function renderCard(p) {
                 <div class="card-brand">${catIcon} ${esc(p.brand)}</div>
                 <div class="card-name">${esc(p.name)}</div>
                 ${p.colorway ? `<div class="card-colorway">${esc(p.colorway)}</div>` : ''}
+                ${sizesHtml}
                 <div class="card-prices">
                     <span class="price-sale">\u20ac${p.sale_price.toFixed(2)}</span>
                     ${p.original_price > p.sale_price


### PR DESCRIPTION
## What this does
Shows available sizes as compact pills on catalogue cards, so users can see at a glance whether their size is in stock without clicking into each product.

## Changes

### Backend (`backend/app.py`)
- Added sizes sub-query inside `list_products()` — fetches in-stock size labels per product (same pattern as the existing image query)
- Each product in `/api/products` response now includes a `sizes` array

### Frontend (`frontend/js/catalog.js`)
- `renderCard()` now renders size pills after the colorway line
- Shows max 8 sizes, then a `+N` pill if there are more (prevents layout overflow)

### CSS (`frontend/css/style.css`)
- Added `.card-sizes`, `.size-pill`, `.size-pill-more` styles
- Uses `--font-mono` and `--bg-secondary` to match the existing dark theme
- Mobile-responsive: smaller pills on screens < 768px

## Before
Cards showed: image, badges, brand, name, colorway, price, store — **no sizes**

## After
Cards show: image, badges, brand, name, colorway, **size pills**, price, store

Closes #9

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/Fashion-/10?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->