### PR TITLE
fix: improve image quality across catalogue and detail pages

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -159,8 +159,9 @@ body {
 .card-image-wrap img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     transition: transform 0.3s;
+    image-rendering: -webkit-optimize-contrast;
 }
 
 .product-card:hover .card-image-wrap img {
@@ -325,7 +326,8 @@ body {
 .gallery-main img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
+    image-rendering: -webkit-optimize-contrast;
 }
 
 .gallery-thumbs {

--- a/frontend/js/catalog.js
+++ b/frontend/js/catalog.js
@@ -9,6 +9,19 @@ const sizeFilter = document.getElementById('filter-size');
 const storeFilter = document.getElementById('filter-store');
 const sortSelect = document.getElementById('sort');
 
+/**
+ * Request a specific size from Shopify CDN.
+ * Transforms URLs like: ...image_small.jpg -> ...image_600x.jpg
+ * Works with Shopify's _WIDTHx format.
+ */
+function shopifyImg(url, width) {
+    if (!url) return '';
+    // Remove any existing Shopify size suffix
+    url = url.replace(/_(pico|icon|thumb|small|compact|medium|large|grande|original|master|\d+x\d*|\d*x\d+)\./i, '.');
+    // Insert new size before file extension
+    return url.replace(/(\.[a-z]{3,4})(\?.*)?$/i, `_${width}x$1$2`);
+}
+
 async function loadStores() {
     try {
         const res = await fetch(`${API_BASE}/api/stores`);
@@ -126,8 +139,10 @@ function renderCard(p) {
     const catLabels = { sneakers: '\ud83d\udc5f', clothing: '\ud83d\udc55', accessories: '\ud83c\udfa9', kids: '\ud83e\udde1', toddler: '\ud83d\udc76' };
     const catIcon = catLabels[p.category] || '';
 
+    // Request 600px wide image for card grid (sharp on most screens incl. retina)
+    const cardImgUrl = shopifyImg(p.image_url, 600);
     const imgHtml = p.image_url
-        ? `<img src="${p.image_url}" alt="${p.name}" loading="lazy">`
+        ? `<img src="${cardImgUrl}" alt="${p.name}" loading="lazy">`
         : '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted)">No image</div>';
 
     // Render size pills (show max 8, then "+N more")

--- a/frontend/js/product.js
+++ b/frontend/js/product.js
@@ -6,6 +6,15 @@ const container = document.getElementById('product-detail');
 let currentSlug = null;
 let currentCategory = null;
 
+/**
+ * Request a specific size from Shopify CDN.
+ */
+function shopifyImg(url, width) {
+    if (!url) return '';
+    url = url.replace(/_(pico|icon|thumb|small|compact|medium|large|grande|original|master|\d+x\d*|\d*x\d+)\./i, '.');
+    return url.replace(/(\.[a-z]{3,4})(\?.*)?$/i, `_${width}x$1$2`);
+}
+
 async function loadProduct() {
     const params = new URLSearchParams(window.location.search);
     const slug = params.get('slug');
@@ -48,7 +57,7 @@ function renderDetail(p) {
 
     const thumbs = p.images.map((img, i) => `
         <div class="gallery-thumb ${i === 0 ? 'active' : ''}" data-index="${i}">
-            <img src="${img.image_url}" alt="${img.alt_text || p.name}">
+            <img src="${shopifyImg(img.image_url, 150)}" alt="${img.alt_text || p.name}">
         </div>
     `).join('');
 
@@ -73,7 +82,7 @@ function renderDetail(p) {
     return `
         <div class="detail-gallery">
             <div class="gallery-main">
-                ${mainImg ? `<img id="main-image" src="${mainImg}" alt="${esc(p.name)}">` : ''}
+                ${mainImg ? `<img id="main-image" src="${shopifyImg(mainImg, 1200)}" alt="${esc(p.name)}">` : ''}
             </div>
             ${p.images.length > 1 ? `<div class="gallery-thumbs">${thumbs}</div>` : ''}
         </div>
@@ -212,7 +221,7 @@ function initGallery(images) {
     document.querySelectorAll('.gallery-thumb').forEach(thumb => {
         thumb.addEventListener('click', () => {
             const idx = parseInt(thumb.dataset.index);
-            mainImg.src = images[idx].image_url;
+            mainImg.src = shopifyImg(images[idx].image_url, 1200);
             document.querySelectorAll('.gallery-thumb').forEach(t => t.classList.remove('active'));
             thumb.classList.add('active');
         });


### PR DESCRIPTION
## Problem
Product images on catalogue cards and detail page appear blurry — Shopify CDN serves small default images, and `object-fit: cover` crops them.

## Fix

### `shopifyImg()` helper (both JS files)
Transforms Shopify CDN URLs to request a specific width:
- `image.jpg` → `image_600x.jpg` (cards)
- `image.jpg` → `image_1200x.jpg` (detail main)
- `image.jpg` → `image_150x.jpg` (detail thumbs)

Strips any existing Shopify size suffix first (`_small`, `_medium`, etc.), then inserts the requested width.

### CSS changes
- Card images: `object-fit: cover` → `object-fit: contain` — no more cropping, full shoe visible
- Detail main image: same `contain` treatment
- Added `image-rendering: -webkit-optimize-contrast` for sharper rendering on webkit browsers

### Resolution breakdown
| Location | Before | After |
|----------|--------|-------|
| Card grid | ~200-300px (default) | 600px (retina-sharp) |
| Detail main | whatever came from API | 1200px |
| Detail thumbs | full-size image scaled down | 150px (correct size) |
| Gallery click | raw URL | 1200px |

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/Fashion-/13?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->